### PR TITLE
Removed override on some Get- functions in Skill_Repair

### DIFF
--- a/replaceRepair/skill_repair.lua
+++ b/replaceRepair/skill_repair.lua
@@ -14,12 +14,12 @@ local this = {}
 local fields = {
 	"Name",				-- displays
 	"Description",		-- displays
-	"Class",			-- no display
+	--"Class",			-- no display. Causes bizarre crashes
 	"PathSize",
 	"MinDamage",		-- displays?
 	"Damage",			-- displays
 	"SelfDamage",		-- displays
-	"Limited",			-- shows up on tooltip, but doesn't seem to do anything. limited could be modded.
+	--"Limited",		-- shows up on tooltip, but doesn't seem to do anything. Causes bizarre crashes
 	"LaunchSound",		-- no sound in tipimage
 	"ImpactSound",		-- no sound in tipimage
 	"ProjectileArt",


### PR DESCRIPTION
It was identified that using the console command `leave` to finish and island, would crash the game when entering the next island.

Replace Repair overrides most of the `Get-` functions in Skill_Repair in order to get data from the current displayed custom repair skill.

The game appears to call `Skill_Repair.GetClass` and `Skill_Repair.GetLimited` when entering an island; which seemingly can crash the game. There could be an issue with the overriden functions themselves.
However, since both `Class` and `Limited` are not very useful to custom repair skills (Class will not be displayed, and Limited will not count down when using the repair skill), they have now been removed from Replace Repair.

If more crashes are linked to Replace Repair after this, it could be useful to investigate the remaining function overrides and/or the override code itself for additional errors.